### PR TITLE
Add support for non standard resolutions

### DIFF
--- a/reference_importer_main/imageSequence.py
+++ b/reference_importer_main/imageSequence.py
@@ -6,7 +6,8 @@ import platform
 from pathlib import Path
 
 TIMECODE_REGEX = r"Duration: (\d{2}:\d{2}:\d{2}.\d)"
-
+DIMENSIONS_REGEX = r"Video.*[ ,](\d+)x(\d+),"
+DIMENSIONS_SAR_DAR_REGEX = r"(\d+)x(\d+) \[SAR (\d+):(\d+) DAR (\d+):(\d+)\]"
 
 class FfmpegError(Exception):
     ...
@@ -14,6 +15,13 @@ class FfmpegError(Exception):
 class MissingFfmpeg(FfmpegError):
     ...
 
+class Dimensions:
+    w: int
+    h: int
+    sar_w: int
+    sar_h: int
+    dar_w: int
+    dar_h: int
 
 class ImageSequencer:
     def __init__(
@@ -91,6 +99,57 @@ class ImageSequencer:
         duration: str = str(match.groups(0)[0])
         return duration
 
+    def get_dimensions(self, video_file: str) -> Dimensions:
+        """Gets the dimensions of the video from the output of ffmpeg -i.
+
+        Args:
+            video_file: Video file.
+
+        Raises:
+            FfmpegError: If ffmpeg errors out and does not yield an output.
+            ValueError: If there is no match for the dimensions in ffmpeg's output.
+
+        Returns:
+            Dimensions of the video.
+        """
+        command = f'"{self.ffmpeg_path}" -i "{video_file}"'
+        try:
+            output = str(
+                subprocess.run(
+                    command,
+                    shell=True,
+                    stderr=subprocess.STDOUT,
+                    stdout=subprocess.PIPE,
+                    check=False,
+                ),
+            )
+
+        except subprocess.CalledProcessError as e:
+            _except_msg: str = "Unable to get ffmpeg output"
+            raise FfmpegError(_except_msg) from e
+
+        with_sar_dar: bool = True
+        # re.search searches across the whole string (multiline output).
+        match: re.Match | None = re.search(DIMENSIONS_SAR_DAR_REGEX, output)
+
+        if not match:
+            with_sar_dar = False
+            match: re.Match | None = re.search(DIMENSIONS_REGEX, output)
+
+        if not match:
+            _except_msg: str = f"Unable to find Dimensions for video {video_file}"
+            raise ValueError(_except_msg)
+
+        dimensions = Dimensions()
+        dimensions.w = int(match.groups(0)[0])
+        dimensions.h = int(match.groups(0)[1])
+        dimensions.sar_w = int(match.groups(0)[2]) if with_sar_dar else 1
+        dimensions.sar_h = int(match.groups(0)[3]) if with_sar_dar else 1
+        dimensions.dar_w = int(match.groups(0)[4]) if with_sar_dar else 1
+        dimensions.dar_h = int(match.groups(0)[5]) if with_sar_dar else 1
+
+        return dimensions
+
     def create_sequence(
         self,
         input_file: str,
@@ -99,9 +158,12 @@ class ImageSequencer:
         end_trim: str,
         output_file: str,
     ):
+        dimensions = self.get_dimensions(input_file)
+        scale_x = dimensions.w
+        scale_y = round(dimensions.h * (float(dimensions.sar_h) / float(dimensions.sar_w)))
         command = (
             f'"{self.ffmpeg_path}" -i "{input_file}" -r {frame_rate}'
-            f" -vf scale=1280:-1 -q:v 3 -ss {start_trim} -to {end_trim} "
+            f" -vf scale={scale_x}:{scale_y} -q:v 3 -ss {start_trim} -to {end_trim} "
             f'"{output_file}"'
         )
         try:

--- a/reference_importer_main/imageSequence.py
+++ b/reference_importer_main/imageSequence.py
@@ -6,8 +6,10 @@ import platform
 from pathlib import Path
 
 TIMECODE_REGEX = r"Duration: (\d{2}:\d{2}:\d{2}.\d)"
-DIMENSIONS_REGEX = r"Video.*[ ,](\d+)x(\d+),"
-DIMENSIONS_SAR_DAR_REGEX = r"(\d+)x(\d+) \[SAR (\d+):(\d+) DAR (\d+):(\d+)\]"
+DIMENSIONS_SIZE_REGEX = r"Video.*[ ,](\d+)x(\d+)(,| \[)"
+DIMENSIONS_SAR_REGEX = r"Video.*SAR (\d+):(\d+)"
+DIMENSIONS_DAR_REGEX = r"Video.*DAR (\d+):(\d+)"
+ROTATION_90_REGEX = r"displaymatrix.*90.*degrees"
 
 class FfmpegError(Exception):
     ...
@@ -128,13 +130,8 @@ class ImageSequencer:
             _except_msg: str = "Unable to get ffmpeg output"
             raise FfmpegError(_except_msg) from e
 
-        with_sar_dar: bool = True
         # re.search searches across the whole string (multiline output).
-        match: re.Match | None = re.search(DIMENSIONS_SAR_DAR_REGEX, output)
-
-        if not match:
-            with_sar_dar = False
-            match: re.Match | None = re.search(DIMENSIONS_REGEX, output)
+        match: re.Match | None = re.search(DIMENSIONS_SIZE_REGEX, output)
 
         if not match:
             _except_msg: str = f"Unable to find Dimensions for video {video_file}"
@@ -143,10 +140,19 @@ class ImageSequencer:
         dimensions = Dimensions()
         dimensions.w = int(match.groups(0)[0])
         dimensions.h = int(match.groups(0)[1])
-        dimensions.sar_w = int(match.groups(0)[2]) if with_sar_dar else 1
-        dimensions.sar_h = int(match.groups(0)[3]) if with_sar_dar else 1
-        dimensions.dar_w = int(match.groups(0)[4]) if with_sar_dar else 1
-        dimensions.dar_h = int(match.groups(0)[5]) if with_sar_dar else 1
+
+        match: re.Match | None = re.search(DIMENSIONS_SAR_REGEX, output)
+        dimensions.sar_w = int(match.groups(0)[0]) if match else 1
+        dimensions.sar_h = int(match.groups(0)[1]) if match else 1
+
+        match: re.Match | None = re.search(DIMENSIONS_DAR_REGEX, output)
+        dimensions.dar_w = int(match.groups(0)[0]) if match else 1
+        dimensions.dar_h = int(match.groups(0)[1]) if match else 1
+
+        # Revert w and h if we find rotation information
+        match: re.Match | None = re.search(ROTATION_90_REGEX, output)
+        if match:
+            dimensions.w, dimensions.h = dimensions.h, dimensions.w
 
         return dimensions
 

--- a/reference_importer_main/imageSequence.py
+++ b/reference_importer_main/imageSequence.py
@@ -149,7 +149,7 @@ class ImageSequencer:
         dimensions.dar_w = int(match.groups(0)[0]) if match else 1
         dimensions.dar_h = int(match.groups(0)[1]) if match else 1
 
-        # Revert w and h if we find rotation information
+        # Swap w and h if we find rotation information
         match: re.Match | None = re.search(ROTATION_90_REGEX, output)
         if match:
             dimensions.w, dimensions.h = dimensions.h, dimensions.w


### PR DESCRIPTION
When using recordings from mobile phones with vertical aspect ratios, the dimensions of the video can be encoded in a non standard resolution, adding additional information in a SAR / DAR section.

For example:
```
Stream #0:0[0x1](und): Video: h264 (Main) (avc1 / 0x31637661), yuv420p(tv, bt709, progressive), 1080x720 [SAR 3:8 DAR 9:16], 1743 kb/s, 29.92 fps, 29.92 tbr, 90k tbn (default)
```
or with rotation information
```
Stream #0:2[0x3](eng): Video: hevc (Main) (hvc1 / 0x31637668), yuvj420p(pc, bt709), 1920x1080, 20286 kb/s, SAR 1:1 DAR 16:9, 29.99 fps, 30 tbr, 90k tbn (default)
...
  displaymatrix: rotation of -90.00 degrees
```

Use SAR information to calculate the size of the output images. In the first example, `1080x1920`.
Swap `width` and `height` if we find rotation information of -90 or 90 degrees.

The testing of this code has not been exhaustive, I have only tested it with vertical/horizontal recordings of a couple of Android phones, but videos with no SAR/DAR information encoded should not be affected.
